### PR TITLE
Cannot find `spiderpig 1.1.0-dev`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,6 @@ scipy==0.18.0
 seaborn==0.7.1
 simplegeneric==0.8.1
 six==1.10.0
-spiderpig==1.1.0-dev
+spiderpig==2.1.0
 traitlets==4.2.2
 wcwidth==0.1.7


### PR DESCRIPTION
I could not find spiderpig 1.1.0-dev on pypi or https://github.com/papousek/spiderpig/releases 
I assume v2.1 is acceptable to use for this?